### PR TITLE
Fix build (less.rs)

### DIFF
--- a/src/bin/less.rs
+++ b/src/bin/less.rs
@@ -38,8 +38,10 @@ static LONG_HELP: &'static str = r#"
 
 fn main() {
     let mut args = args().skip(1);
-    let mut stdout = io::stdout().lock();
-    let mut stdin = io::stdin().lock();
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
     let mut stderr = io::stderr();
 
     if let Some(x) = args.next() {


### PR DESCRIPTION
This PR fixes the following build error:
```
src/bin/less.rs:41:22: 41:34 error: borrowed value does not live long enough
src/bin/less.rs:41     let mut stdout = io::stdout().lock();
                                        ^~~~~~~~~~~~
src/bin/less.rs:40:35: 66:2 note: reference must be valid for the block suffix following statement 0 at 40:34...
src/bin/less.rs:40     let mut args = args().skip(1);
src/bin/less.rs:41     let mut stdout = io::stdout().lock();
src/bin/less.rs:42     let mut stdin = io::stdin().lock();
src/bin/less.rs:43     let mut stderr = io::stderr();
src/bin/less.rs:44
src/bin/less.rs:45     if let Some(x) = args.next() {
                   ...
src/bin/less.rs:41:5: 41:42 note: ...but borrowed value is only valid for the statement at 41:4
src/bin/less.rs:41     let mut stdout = io::stdout().lock();
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/bin/less.rs:41:5: 41:42 help: consider using a `let` binding to increase its lifetime
src/bin/less.rs:41     let mut stdout = io::stdout().lock();
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/bin/less.rs:42:21: 42:32 error: borrowed value does not live long enough
src/bin/less.rs:42     let mut stdin = io::stdin().lock();
                                       ^~~~~~~~~~~
src/bin/less.rs:41:42: 66:2 note: reference must be valid for the block suffix following statement 1 at 41:41...
src/bin/less.rs:41     let mut stdout = io::stdout().lock();
src/bin/less.rs:42     let mut stdin = io::stdin().lock();
src/bin/less.rs:43     let mut stderr = io::stderr();
src/bin/less.rs:44
src/bin/less.rs:45     if let Some(x) = args.next() {
src/bin/less.rs:46         match x.as_str() {
                   ...
src/bin/less.rs:42:5: 42:40 note: ...but borrowed value is only valid for the statement at 42:4
src/bin/less.rs:42     let mut stdin = io::stdin().lock();
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/bin/less.rs:42:5: 42:40 help: consider using a `let` binding to increase its lifetime
src/bin/less.rs:42     let mut stdin = io::stdin().lock();
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 2 previous errors
Build failed, waiting for other jobs to finish...
       error Could not compile `extrautils`.

```