### PR TITLE
Removed feature question_mark

### DIFF
--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![feature(question_mark)]
 
 // TODO support reading from standard input
 


### PR DESCRIPTION
This feature is now in Rust stable, so adding `!#[feature(question_mark)]` is now useless and causes a warning.