### PR TITLE
screenfetch: Trim trailing whitespace from CPU

### DIFF
--- a/src/bin/screenfetch.rs
+++ b/src/bin/screenfetch.rs
@@ -42,7 +42,7 @@ fn main() {
         let cpuid = raw_cpuid::CpuId::new();
         if let Some(info) = cpuid.get_extended_function_info() {
             if let Some(brand) = info.processor_brand_string() {
-                cpu = brand.to_string();
+                cpu = brand.trim().to_string();
             }
         }
     }


### PR DESCRIPTION
The raw_cpuid crate passes the CPU brand string with trailing whitespace which borks the output. According to the tests of that crate it's [an expected behaviour](https://github.com/gz/rust-cpuid/blob/c3ebfc553cdff98d19d29777fd85c4f9182bfb66/src/lib.rs#L2443) so the whitespace needs to be removed here.