### PR TITLE
remove unused "use" of AsciiExt

### DIFF
--- a/src/bin/mtxt.rs
+++ b/src/bin/mtxt.rs
@@ -3,15 +3,14 @@
 
 extern crate extra;
 
-use std::ascii::AsciiExt;
 use std::env::args;
-use std::io::{self, Write, Read};
+use std::io::{self, Read, Write};
 use std::process::exit;
 
 use extra::option::OptionalExt;
 use extra::io::{fail, WriteExt};
 
-static HELP: &'static str = /* @MANSTART{mtxt} */ r#"
+static HELP: &'static str = r#"
 NAME
     mtxt - a simple tool to manipulate text from standard input.
 
@@ -91,7 +90,7 @@ fn main() {
             "-h" | "--help" => {
                 // The help page.
                 stdout.write(HELP.as_bytes()).try(&mut stderr);
-            },
+            }
             a => {
                 // The argument, a, is unknown.
                 stderr.write(b"error: unknown argument, ").try(&mut stderr);
@@ -99,7 +98,7 @@ fn main() {
                 stderr.write(b".\n").try(&mut stderr);
                 stderr.flush().try(&mut stderr);
                 exit(1);
-            },
+            }
         }
     }
 
@@ -124,12 +123,16 @@ fn main() {
 
         // If -u is set, convert to uppercase
         if to_uppercase {
-            for uppercase in i.to_uppercase().filter(|x| !strip_non_ascii || x.is_ascii() ) {
+            for uppercase in i.to_uppercase()
+                .filter(|x| !strip_non_ascii || x.is_ascii())
+            {
                 stdout.write_char(uppercase).try(&mut stderr);
             }
         // If -l is set, convert to lowercase
         } else if to_lowercase {
-            for lowercase in i.to_lowercase().filter(|x| !strip_non_ascii || x.is_ascii()) {
+            for lowercase in i.to_lowercase()
+                .filter(|x| !strip_non_ascii || x.is_ascii())
+            {
                 stdout.write_char(lowercase).try(&mut stderr);
             }
         // If -a is set, strip non-ASCII.

--- a/src/bin/mtxt.rs
+++ b/src/bin/mtxt.rs
@@ -10,7 +10,7 @@ use std::process::exit;
 use extra::option::OptionalExt;
 use extra::io::{fail, WriteExt};
 
-static HELP: &'static str = r#"
+static HELP: &'static str = /* @MANSTART{mtxt} */ r#"
 NAME
     mtxt - a simple tool to manipulate text from standard input.
 


### PR DESCRIPTION
As of 1.23 stable, 
one now longer needs to import std::ascii::AsciiExt. See changelog for 1.23.
Also fixed few formatting issues.